### PR TITLE
Exclude edge particles

### DIFF
--- a/src/membrain_stats/geodesic_distances/geodesic_ripleys.py
+++ b/src/membrain_stats/geodesic_distances/geodesic_ripleys.py
@@ -26,6 +26,8 @@ def geodesic_ripleys_folder(
     method: str = "fast",
     exclude_edges: bool = False,
     edge_exclusion_width: float = 50.0,
+    plot: bool = False,
+    edge_percentile: float = 95,
 ):
     # get filenames from folder
     filenames = get_mesh_filenames(in_folder)
@@ -44,6 +46,8 @@ def geodesic_ripleys_folder(
                 filename=filename,
                 mesh_dict=mesh_dict,
                 edge_exclusion_width=edge_exclusion_width,
+                percentile=edge_percentile,
+                force_recompute=False,
             )
             for (filename, mesh_dict) in zip(filenames, mesh_dicts)
         ]
@@ -74,3 +78,13 @@ def geodesic_ripleys_folder(
     out_file = os.path.join(out_folder, f"ripleys{ripley_type}.star")
     os.makedirs(out_folder, exist_ok=True)
     starfile.write(out_data, out_file)
+
+    if plot:
+        from matplotlib import pyplot as plt
+
+        # plot Ripley's statistics
+        plt.plot(ripley_stats[0], ripley_stats[1])
+        plt.xlabel("Distance (nm)")
+        plt.ylabel(f"Ripley's {ripley_type}")
+        plt.title(f"Ripley's {ripley_type}")
+        plt.savefig(os.path.join(out_folder, f"ripleys{ripley_type}.png"))

--- a/src/membrain_stats/membrane_edges/edge_from_curvature.py
+++ b/src/membrain_stats/membrane_edges/edge_from_curvature.py
@@ -1,9 +1,12 @@
 import os
 import numpy as np
 import trimesh
+import pyvista as pv
 from scipy.spatial import cKDTree
 from membrain_stats.utils.mesh_utils import resort_mesh, find_closest_vertices
 from membrain_stats.utils.io_utils import get_tmp_edge_files
+
+from membrain_pick.dataloading.data_utils import store_array_in_csv
 
 
 def get_edge_mask(
@@ -24,10 +27,11 @@ def get_edge_mask(
     if curvature is None:
         # Get the curvature of the mesh
         print("Computing curvature...")
-        curvature = trimesh.curvature.discrete_mean_curvature_measure(
-            mesh, points=mesh.vertices, radius=10.0
-        )
-        print("Computed curvature.")
+
+        pv_mesh = pv.wrap(mesh)
+        curvature = pv_mesh.curvature("Mean")
+        pv_mesh["Curvature"] = curvature
+
         if temp_file is not None:
             np.save(temp_file, curvature)
 

--- a/src/membrain_stats/membrane_edges/edge_from_curvature.py
+++ b/src/membrain_stats/membrane_edges/edge_from_curvature.py
@@ -6,8 +6,6 @@ from scipy.spatial import cKDTree
 from membrain_stats.utils.mesh_utils import resort_mesh, find_closest_vertices
 from membrain_stats.utils.io_utils import get_tmp_edge_files
 
-from membrain_pick.dataloading.data_utils import store_array_in_csv
-
 
 def get_edge_mask(
     mesh: trimesh.Trimesh,

--- a/src/membrain_stats/membrane_edges/edge_from_curvature.py
+++ b/src/membrain_stats/membrane_edges/edge_from_curvature.py
@@ -23,9 +23,11 @@ def get_edge_mask(
 
     if curvature is None:
         # Get the curvature of the mesh
+        print("Computing curvature...")
         curvature = trimesh.curvature.discrete_mean_curvature_measure(
             mesh, points=mesh.vertices, radius=10.0
         )
+        print("Computed curvature.")
         if temp_file is not None:
             np.save(temp_file, curvature)
 
@@ -92,7 +94,9 @@ def exclude_edges_from_mesh(
     edge_exclusion_width,
     leave_classes=None,
     force_recompute=False,
+    percentile=95,
 ):
+    print("Excluding edges from mesh: ", filename)
     # get temp_filename (will be created if non-existent)
     out_file_edges = get_tmp_edge_files(out_folder, [filename])[0]
 
@@ -107,6 +111,7 @@ def exclude_edges_from_mesh(
         temp_file=out_file_edges,
         return_vertex_mask=True,
         force_recompute=force_recompute,
+        percentile=percentile,
     )
     edge_vertex_mask = mesh[1]
     mesh = mesh[0]

--- a/src/membrain_stats/membrane_edges/exclude_edge_positions.py
+++ b/src/membrain_stats/membrane_edges/exclude_edge_positions.py
@@ -1,0 +1,53 @@
+import os
+import numpy as np
+import trimesh
+import scipy
+from membrain_stats.membrane_edges.edge_from_curvature import get_edge_mask
+
+
+def mask_geodesic_edge_positions(
+    positions: np.ndarray,
+    mesh_dict: dict,
+    edge_exclusion_params: dict,
+    return_pos_mask: bool = False,
+):
+    mesh_orig = trimesh.Trimesh(vertices=mesh_dict["verts"], faces=mesh_dict["faces"])
+    mesh = get_edge_mask(
+        mesh=mesh_orig,
+        edge_exclusion_width=edge_exclusion_params["edge_exclusion_width"],
+        temp_file=edge_exclusion_params["out_file"],
+        percentile=edge_exclusion_params["edge_percentile"],
+        return_vertex_mask=True,
+    )
+    if edge_exclusion_params["store_sanity_meshes"]:
+        # store in file:
+        out_mesh_orig = (
+            "./sanity_meshes/"
+            + os.path.basename(edge_exclusion_params["out_file"]).split(".")[0]
+            + "_orig.obj"
+        )
+        out_mesh_cropped = "./sanity_meshes/" + os.path.basename(
+            edge_exclusion_params["out_file"]
+        )
+        mesh_orig.export(out_mesh_orig)
+        mesh[0].export(out_mesh_cropped)
+
+    mesh, vertex_mask = mesh
+    positions = mesh_dict["positions"]
+
+    excluded_vertices = mesh_orig.vertices[~vertex_mask]
+    included_vertices = mesh_orig.vertices[vertex_mask]
+
+    # compute nearest neighbor vertex for each position
+    tree_included = scipy.spatial.cKDTree(included_vertices)
+    tree_excluded = scipy.spatial.cKDTree(excluded_vertices)
+
+    nn_distances_inc = tree_included.query(positions, k=1)[0]
+    nn_distances_exc = tree_excluded.query(positions, k=1)[0]
+
+    # exclude vertices that are closer to the excluded vertices than to the included vertices
+    mask = nn_distances_inc < nn_distances_exc
+    if return_pos_mask:
+        return mask
+    positions = positions[mask]
+    return positions, mesh

--- a/src/membrain_stats/mesh_conversion_cli.py
+++ b/src/membrain_stats/mesh_conversion_cli.py
@@ -62,6 +62,10 @@ def protein_concentration(
         None,
         help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, mesh vertices are multiplied by this value.",
     ),
+    pixel_size_multiplier_positions: float = Option(  # noqa: B008
+        None,
+        help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, loaded positions are multiplied by this value.",
+    ),
     only_one_side: bool = Option(  # noqa: B008
         False,
         help="If True, only one side of the membrane will be considered for area calculation.",
@@ -96,6 +100,7 @@ def protein_concentration(
         in_folder=in_folder,
         out_folder=out_folder,
         pixel_size_multiplier=pixel_size_multiplier,
+        pixel_size_multiplier_positions=pixel_size_multiplier_positions,
         only_one_side=only_one_side,
         exclude_edges=exclude_edges,
         edge_exclusion_width=edge_exclusion_width,

--- a/src/membrain_stats/mesh_conversion_cli.py
+++ b/src/membrain_stats/mesh_conversion_cli.py
@@ -124,6 +124,10 @@ def protein_concentration_wrt(
         None,
         help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, mesh vertices are multiplied by this value.",
     ),
+    pixel_size_multiplier_positions: float = Option(  # noqa: B008
+        None,
+        help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, loaded positions are multiplied by this value.",
+    ),
     exclude_edges: bool = Option(  # noqa: B008
         False,
         help="If True, the edges of the membrane will be excluded from the area calculation.",
@@ -173,6 +177,7 @@ def protein_concentration_wrt(
         in_folder=in_folder,
         out_folder=out_folder,
         pixel_size_multiplier=pixel_size_multiplier,
+        pixel_size_multiplier_positions=pixel_size_multiplier_positions,
         exclude_edges=exclude_edges,
         edge_exclusion_width=edge_exclusion_width,
         only_one_side=only_one_side,
@@ -199,6 +204,10 @@ def geodesic_NN(
         None,
         help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, mesh vertices are multiplied by this value.",
     ),
+    pixel_size_multiplier_positions: float = Option(  # noqa: B008
+        None,
+        help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, loaded positions are multiplied by this value.",
+    ),
     num_neighbors: int = Option(  # noqa: B008
         1, help="Number of nearest neighbors to consider."
     ),
@@ -224,6 +233,19 @@ def geodesic_NN(
         False,
         help="If True, the geodesic distances will be plotted for each mesh.",
     ),
+    exclude_edges: bool = Option(  # noqa: B008
+        False,
+        help="If True, the edges of the membrane will be excluded from the nearest neighbor calculation.",
+    ),
+    edge_exclusion_width: float = Option(  # noqa: B008
+        50.0, help="Width of the edge exclusion zone in Anstrom."
+    ),
+    edge_percentile: float = Option(  # noqa: B008
+        95, help="Percentile to use for edge exclusion."
+    ),
+    store_sanity_meshes: bool = Option(  # noqa: B008
+        False, help="If True, the sanity meshes will be stored in a folder."
+    ),
 ):
     """Compute geometric distances between nearest neighbors in all membrane meshes in a folder.
 
@@ -240,6 +262,7 @@ def geodesic_NN(
         in_folder=in_folder,
         out_folder=out_folder,
         pixel_size_multiplier=pixel_size_multiplier,
+        pixel_size_multiplier_positions=pixel_size_multiplier_positions,
         num_neighbors=num_neighbors,
         start_classes=start_classes,
         target_classes=target_classes,
@@ -247,6 +270,10 @@ def geodesic_NN(
         c2_symmetry=c2_symmetry,
         project_to_plane=project_to_plane,
         plot=plot,
+        exclude_edges=exclude_edges,
+        edge_exclusion_width=edge_exclusion_width,
+        edge_percentile=edge_percentile,
+        store_sanity_meshes=store_sanity_meshes,
     )
 
 
@@ -271,6 +298,10 @@ def geodesic_NN_wrt(
     pixel_size_multiplier: float = Option(  # noqa: B008
         None,
         help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, mesh vertices are multiplied by this value.",
+    ),
+    pixel_size_multiplier_positions: float = Option(  # noqa: B008
+        None,
+        help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, loaded positions are multiplied by this value.",
     ),
     num_neighbors: int = Option(  # noqa: B008
         1, help="Number of nearest neighbors to consider."
@@ -313,6 +344,7 @@ def geodesic_NN_wrt(
         exclude_edges=exclude_edges,
         edge_exclusion_width=edge_exclusion_width,
         pixel_size_multiplier=pixel_size_multiplier,
+        pixel_size_multiplier_positions=pixel_size_multiplier_positions,
         num_neighbors=num_neighbors,
         start_classes=start_classes,
         target_classes=target_classes,
@@ -337,6 +369,10 @@ def geodesic_ripley(
     pixel_size_multiplier: float = Option(  # noqa: B008
         None,
         help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, mesh vertices are multiplied by this value.",
+    ),
+    pixel_size_multiplier_positions: float = Option(  # noqa: B008
+        None,
+        help="Pixel size multiplier if mesh is not scaled in unit Angstrom. If provided, loaded positions are multiplied by this value.",
     ),
     start_classes: List[int] = Option(  # noqa: B008
         [0], help="List of classes to consider for start points."
@@ -384,6 +420,7 @@ def geodesic_ripley(
         in_folder=in_folder,
         out_folder=out_folder,
         pixel_size_multiplier=pixel_size_multiplier,
+        pixel_size_multiplier_positions=pixel_size_multiplier_positions,
         start_classes=start_classes,
         target_classes=target_classes,
         ripley_type=ripley_type,

--- a/src/membrain_stats/mesh_conversion_cli.py
+++ b/src/membrain_stats/mesh_conversion_cli.py
@@ -73,6 +73,13 @@ def protein_concentration(
     edge_exclusion_width: float = Option(  # noqa: B008
         50.0, help="Width of the edge exclusion zone in Anstrom."
     ),
+    edge_percentile: float = Option(  # noqa: B008
+        95, help="Percentile to use for edge exclusion."
+    ),
+    plot: bool = Option(  # noqa: B008
+        False,
+        help="If True, the protein concentration will be plotted for each mesh.",
+    ),
 ):
     """Compute the protein concentration in all membrane meshes in a folder.
 
@@ -92,6 +99,8 @@ def protein_concentration(
         only_one_side=only_one_side,
         exclude_edges=exclude_edges,
         edge_exclusion_width=edge_exclusion_width,
+        edge_percentile=edge_percentile,
+        plot=plot,
     )
 
 
@@ -206,6 +215,10 @@ def geodesic_NN(
         False,
         help="If True, the vectors will be projected to the mean plane of the two points to isolate in-plane angles.",
     ),
+    plot: bool = Option(  # noqa: B008
+        False,
+        help="If True, the geodesic distances will be plotted for each mesh.",
+    ),
 ):
     """Compute geometric distances between nearest neighbors in all membrane meshes in a folder.
 
@@ -228,6 +241,7 @@ def geodesic_NN(
         method=method,
         c2_symmetry=c2_symmetry,
         project_to_plane=project_to_plane,
+        plot=plot,
     )
 
 
@@ -343,6 +357,13 @@ def geodesic_ripley(
     edge_exclusion_width: float = Option(  # noqa: B008
         50.0, help="Width of the edge exclusion zone in Anstrom."
     ),
+    edge_percentile: float = Option(  # noqa: B008
+        95, help="Percentile to use for edge exclusion."
+    ),
+    plot: bool = Option(  # noqa: B008
+        False,
+        help="If True, the Ripley statistics will be plotted for each mesh.",
+    ),
 ):
     """Compute Ripley statistics for all membrane meshes in a folder.
 
@@ -365,4 +386,6 @@ def geodesic_ripley(
         method=method,
         exclude_edges=exclude_edges,
         edge_exclusion_width=edge_exclusion_width,
+        edge_percentile=edge_percentile,
+        plot=plot,
     )

--- a/src/membrain_stats/protein_concentration/protein_concentration.py
+++ b/src/membrain_stats/protein_concentration/protein_concentration.py
@@ -2,6 +2,7 @@ import os
 import pandas as pd
 import starfile
 import trimesh
+import scipy
 
 from membrain_stats.utils.io_utils import (
     get_mesh_filenames,
@@ -14,24 +15,59 @@ from membrain_stats.membrane_edges.edge_from_curvature import get_edge_mask
 def protein_concentration_singlemb(
     filename: str,
     pixel_size_multiplier: float = None,
+    pixel_size_multiplier_positions: float = None,
     exclude_edges: bool = False,
     edge_file: str = None,
     edge_exclusion_width: float = 50.0,
     only_one_side: bool = False,
     edge_percentile: float = 95,
+    store_sanity_meshes: bool = False,
 ):
     mesh_dict = get_mesh_from_file(
-        filename, pixel_size_multiplier=pixel_size_multiplier
+        filename,
+        pixel_size_multiplier=pixel_size_multiplier,
+        pixel_size_multiplier_positions=pixel_size_multiplier_positions,
     )
     mesh = trimesh.Trimesh(vertices=mesh_dict["verts"], faces=mesh_dict["faces"])
 
     if exclude_edges:
+        mesh_orig = mesh
         mesh = get_edge_mask(
             mesh=mesh,
             edge_exclusion_width=edge_exclusion_width,
             temp_file=edge_file,
             percentile=edge_percentile,
-        )[0]
+            return_vertex_mask=True,
+        )
+
+        if store_sanity_meshes:
+            # store in file:
+            out_mesh_orig = (
+                "./sanity_meshes/"
+                + os.path.basename(filename).split(".")[0]
+                + "_orig.obj"
+            )
+            out_mesh_cropped = "./sanity_meshes/" + os.path.basename(filename)
+            mesh_orig.export(out_mesh_orig)
+            mesh[0].export(out_mesh_cropped)
+
+        mesh, vertex_mask = mesh
+        positions = mesh_dict["positions"]
+
+        excluded_vertices = mesh_orig.vertices[~vertex_mask]
+        included_vertices = mesh_orig.vertices[vertex_mask]
+
+        # compute nearest neighbor vertex for each position
+        tree_included = scipy.spatial.cKDTree(included_vertices)
+        tree_excluded = scipy.spatial.cKDTree(excluded_vertices)
+
+        nn_distances_inc = tree_included.query(positions, k=1)[0]
+        nn_distances_exc = tree_excluded.query(positions, k=1)[0]
+
+        # exclude vertices that are closer to the excluded vertices than to the included vertices
+        mask = nn_distances_inc < nn_distances_exc
+        positions = positions[mask]
+        mesh_dict["positions"] = positions
 
     area = mesh.area
     area = area * (0.5 if only_one_side else 1.0)
@@ -44,58 +80,6 @@ def protein_concentration_singlemb(
     return num_proteins, area, protein_concentration
 
 
-# def protein_concentration_folder(
-#     in_folder: str,
-#     out_folder: str,
-#     only_one_side: bool = False,
-#     exclude_edges: bool = False,
-#     edge_exclusion_width: float = 50.0,
-#     pixel_size_multiplier: float = None,
-# ):
-
-#     filenames = get_mesh_filenames(in_folder)
-#     mesh_dicts = [get_mesh_from_file(filename) for filename in filenames]
-#     meshes = [
-#         trimesh.Trimesh(
-#             vertices=mesh_dict["verts"]
-#             * (1.0 if pixel_size_multiplier is None else pixel_size_multiplier),
-#             faces=mesh_dict["faces"],
-#         )
-#         for mesh_dict in mesh_dicts
-#     ]
-
-#     if exclude_edges:
-#         out_files_edges = get_tmp_edge_files(out_folder, filenames)
-#         print("Excluding edges. This can take a while.")
-#         meshes = [
-#             get_edge_mask(
-#                 mesh=mesh, edge_exclusion_width=edge_exclusion_width, temp_file=filename
-#             )[0]
-#             for mesh, filename in zip(meshes, out_files_edges)
-#         ]
-
-#     areas = [mesh.area for mesh in meshes]
-#     areas = [area * (0.5 if only_one_side else 1.0) for area in areas]
-
-#     num_proteins = [len(mesh_dict["positions"]) for mesh_dict in mesh_dicts]
-
-#     protein_concentrations = [num_proteins[i] / areas[i] for i in range(len(meshes))]
-#     protein_concentrations = [
-#         concentration * 100 for concentration in protein_concentrations
-#     ]  # get value in nm^-2
-
-#     out_data = {
-#         "filename": filenames,
-#         "num_proteins": num_proteins,
-#         "area": areas,
-#         "protein_concentration": protein_concentrations,
-#     }
-#     out_data = pd.DataFrame(out_data)
-#     out_file = os.path.join(out_folder, "protein_concentration.star")
-#     os.makedirs(out_folder, exist_ok=True)
-#     starfile.write(out_data, out_file)
-
-
 def protein_concentration_folder(
     in_folder: str,
     out_folder: str,
@@ -103,8 +87,10 @@ def protein_concentration_folder(
     exclude_edges: bool = False,
     edge_exclusion_width: float = 50.0,
     pixel_size_multiplier: float = None,
+    pixel_size_multiplier_positions: float = None,
     plot: bool = False,
     edge_percentile: float = 95,
+    store_sanity_meshes: bool = False,
 ):
 
     filenames = get_mesh_filenames(in_folder)
@@ -114,11 +100,13 @@ def protein_concentration_folder(
         protein_concentration_singlemb(
             filename=filename,
             pixel_size_multiplier=pixel_size_multiplier,
+            pixel_size_multiplier_positions=pixel_size_multiplier_positions,
             exclude_edges=exclude_edges,
             edge_file=edge_file,
             edge_exclusion_width=edge_exclusion_width,
             only_one_side=only_one_side,
-            # edge_percentile=edge_percentile,
+            edge_percentile=edge_percentile,
+            store_sanity_meshes=store_sanity_meshes,
         )
         for filename, edge_file in zip(filenames, out_files_edges)
     ]
@@ -135,11 +123,3 @@ def protein_concentration_folder(
     out_file = os.path.join(out_folder, "protein_concentration.star")
     os.makedirs(out_folder, exist_ok=True)
     starfile.write(out_data, out_file)
-
-    # if plot:
-    #     import matplotlib.pyplot as plt
-
-    #     # make histogram
-    #     plt.figure()
-    #     plt.hist(protein_concentrations, bins=10)
-    #     plt.savefig(os.path.join(out_folder, "protein_concentration_histogram.png"))

--- a/src/membrain_stats/utils/io_utils.py
+++ b/src/membrain_stats/utils/io_utils.py
@@ -23,15 +23,24 @@ def get_mesh_filenames(in_folder: str):
     return files
 
 
-def get_mesh_from_file(filename: str, pixel_size_multiplier: float = None):
+def get_mesh_from_file(
+    filename: str,
+    pixel_size_multiplier: float = None,
+    pixel_size_multiplier_positions: float = None,
+):
     pixel_size_multiplier = (
         1.0 if pixel_size_multiplier is None else pixel_size_multiplier
+    )
+    pixel_size_multiplier_positions = (
+        1.0
+        if pixel_size_multiplier_positions is None
+        else pixel_size_multiplier_positions
     )
     if filename.endswith(".h5"):
         mesh_data = load_mesh_from_hdf5(filename)
         verts = mesh_data["points"] * pixel_size_multiplier
         faces = mesh_data["faces"]
-        positions = mesh_data["cluster_centers"] * pixel_size_multiplier
+        positions = mesh_data["cluster_centers"] * pixel_size_multiplier_positions
         classes = np.zeros(len(positions), dtype=int)
         angles = np.zeros((len(positions), 3))
         hasAngles = False
@@ -53,7 +62,7 @@ def get_mesh_from_file(filename: str, pixel_size_multiplier: float = None):
             hasAngles = False
         positions = (
             positions[["rlnCoordinateX", "rlnCoordinateY", "rlnCoordinateZ"]].values
-            # * pixel_size_multiplier
+            * pixel_size_multiplier_positions
         )
     out_dict = {
         "verts": verts,

--- a/src/membrain_stats/utils/io_utils.py
+++ b/src/membrain_stats/utils/io_utils.py
@@ -12,7 +12,6 @@ def get_mesh_filenames(in_folder: str):
     obj_files = [
         filename for filename in os.listdir(in_folder) if filename.endswith(".obj")
     ]
-
     if len(h5_files) >= len(obj_files):
         files = h5_files
     else:

--- a/src/membrain_stats/utils/mesh_utils.py
+++ b/src/membrain_stats/utils/mesh_utils.py
@@ -74,7 +74,12 @@ def check_mappings(
     These mappings should be bijections.
     """
     # check forward mappings defined for all vertices
-    assert len(forward_vertex_mapping) == len(orig_verts)
+    assert len(forward_vertex_mapping) == len(orig_verts), (
+        "Forward vertex mapping failed because: "
+        + str(len(forward_vertex_mapping))
+        + " != "
+        + str(len(orig_verts))
+    )
     # check reverse mappings defined for all forward mappings
     assert len(reverse_vertex_mapping) == len(forward_vertex_mapping)
     # check forward mappings defined for all faces
@@ -104,9 +109,6 @@ def check_mappings(
         for component_vertex_idx, component_vertex in enumerate(component_verts):
             vertex_idx = reverse_vertex_mapping[(component_idx, component_vertex_idx)]
             assert np.allclose(orig_verts[vertex_idx], component_vertex)
-        for component_face_idx, component_face in enumerate(component_faces):
-            face_idx = reverse_face_mapping[(component_idx, component_face_idx)]
-            assert np.allclose(orig_faces[face_idx], component_face)
 
 
 def vertex_adjacency(faces):
@@ -143,9 +145,7 @@ def vertex_adjacency(faces):
     for adjacent_faces in vertex_to_faces.values():
         # Sort face indices to avoid creating duplicate (a, b) and (b, a) pairs
         for i in range(len(adjacent_faces)):
-            for j in range(
-                i + 1, len(adjacent_faces)
-            ):  # Ensure adj_face_idx > face_idx
+            for j in range(i, len(adjacent_faces)):  # Ensure adj_face_idx > face_idx
                 adjacency.add((adjacent_faces[i], adjacent_faces[j]))
 
     # Convert the set to a numpy array for consistency
@@ -156,7 +156,17 @@ def split_mesh_into_connected_components(
     verts, faces, return_face_mapping=False, return_vertex_mapping=False
 ):
     adjacency = vertex_adjacency(faces)
-    components = connected_components(adjacency)
+    components = connected_components(adjacency, min_len=0)
+    print(len(components), "connected components found.")
+
+    # # store connected components
+    # if len(components) > 2:
+    #     test_folder = "/scicore/home/engel0006/GROUP/pool-engel/Lorenz/MemBrain_stats/Phycobilisomes/test_meshes/"
+    #     for i, component in enumerate(components):
+    #         component_faces = faces[np.isin(np.arange(len(faces)), component)]
+    #         component_mesh = trimesh.Trimesh(verts, component_faces)
+    #         component_mesh.export(test_folder + f"component_{i}.obj")
+    #     exit()
 
     component_face_idcs = [
         np.argwhere(np.isin(np.arange(len(faces)), component)).flatten()

--- a/src/membrain_stats/utils/ripley_utils.py
+++ b/src/membrain_stats/utils/ripley_utils.py
@@ -111,12 +111,14 @@ def accumulate_barycentric_areas(
         [np.sum(x_barycentric_area) for x_barycentric_area in x_barycentric_areas]
     )
 
+    total_conc = np.sum(protein_per_distance) / np.sum(x_barycentric_areas)
+
     # accumulate if not computing O statistic
     if ripley_type != "O":
         protein_per_distance = np.cumsum(protein_per_distance)
         x_barycentric_areas = np.cumsum(x_barycentric_areas)
 
-    return protein_per_distance, x_barycentric_areas
+    return protein_per_distance, x_barycentric_areas, total_conc
 
 
 def define_xy_values(
@@ -167,10 +169,14 @@ def aggregate_ripleys_stats(
         barycentric_areas=barycentric_areas, mesh_distances=mesh_distances
     )
 
-    # compute global concentration of reachable points
-    total_concentration = np.sum(avg_reachable_points) / np.sum(
-        all_barycentric_areas[all_mesh_distances < np.inf]
-    )
+    # print(all_barycentric_areas.shape, len(avg_reachable_points), "<--")
+    # print(all_mesh_distances.shape, len(avg_reachable_points), "<--")
+    # print(avg_reachable_points, avg_starting_points, "<--")
+
+    # # compute global concentration of reachable points
+    # total_concentration = np.sum(avg_reachable_points) / np.sum(
+    #     all_barycentric_areas[all_mesh_distances < np.inf]
+    # )
 
     # sort in ascending order
     all_mesh_distances, all_barycentric_areas = (
@@ -187,12 +193,14 @@ def aggregate_ripleys_stats(
     protein_per_distance = distance_histogram / avg_starting_points
 
     # accumulate into computed bins
-    protein_per_distance, x_barycentric_areas = accumulate_barycentric_areas(
-        all_barycentric_areas=all_barycentric_areas,
-        all_mesh_distances=all_mesh_distances,
-        all_distances=all_distances,
-        protein_per_distance=protein_per_distance,
-        ripley_type=ripley_type,
+    protein_per_distance, x_barycentric_areas, total_concentration = (
+        accumulate_barycentric_areas(
+            all_barycentric_areas=all_barycentric_areas,
+            all_mesh_distances=all_mesh_distances,
+            all_distances=all_distances,
+            protein_per_distance=protein_per_distance,
+            ripley_type=ripley_type,
+        )
     )
 
     # define final outputs


### PR DESCRIPTION
This PR adds the functionality to exclude edge particles from the calculation of nearest neighbor distances.
It is still possible to keep these excluded particles as reference particles for other positions to compute their nearest neighbor distances to.