### PR TITLE
Make pypi deployment

### DIFF
--- a/src/membrain_stats/geodesic_distances/geodesic_ripleys.py
+++ b/src/membrain_stats/geodesic_distances/geodesic_ripleys.py
@@ -19,10 +19,12 @@ def geodesic_ripleys_folder(
     in_folder: str,
     out_folder: str,
     pixel_size_multiplier: float = None,
+    pixel_size_multiplier_positions: float = None,
     start_classes: List[int] = [0],
     target_classes: List[int] = [0],
     ripley_type: str = "O",
     num_bins: int = 100,
+    bin_size: float = None,
     method: str = "fast",
     exclude_edges: bool = False,
     edge_exclusion_width: float = 50.0,
@@ -34,7 +36,11 @@ def geodesic_ripleys_folder(
 
     # load mehes
     mesh_dicts = [
-        get_mesh_from_file(filename, pixel_size_multiplier=pixel_size_multiplier)
+        get_mesh_from_file(
+            filename,
+            pixel_size_multiplier=pixel_size_multiplier,
+            pixel_size_multiplier_positions=pixel_size_multiplier_positions,
+        )
         for filename in filenames
     ]
 
@@ -65,7 +71,10 @@ def geodesic_ripleys_folder(
 
     # aggregate computed values to output global ripley's statistics
     ripley_stats = aggregate_ripleys_stats(
-        ripley_stats=ripley_stats, ripley_type=ripley_type, num_bins=num_bins
+        ripley_stats=ripley_stats,
+        ripley_type=ripley_type,
+        num_bins=num_bins,
+        bin_size=bin_size,
     )
 
     # store in star file

--- a/src/membrain_stats/mesh_conversion_cli.py
+++ b/src/membrain_stats/mesh_conversion_cli.py
@@ -387,6 +387,7 @@ def geodesic_ripley(
     num_bins: int = Option(  # noqa: B008
         50, help="Into how many bins should the ripley statistics be split?"
     ),
+    bin_size: float = Option(None, help="Size of the bins in Anstrom."),  # noqa: B008
     method: str = Option(  # noqa: B008
         "fast",
         help="Method to use for computing geodesic distances. Can be either 'exact' or 'fast'.",
@@ -425,6 +426,7 @@ def geodesic_ripley(
         target_classes=target_classes,
         ripley_type=ripley_type,
         num_bins=num_bins,
+        bin_size=bin_size,
         method=method,
         exclude_edges=exclude_edges,
         edge_exclusion_width=edge_exclusion_width,

--- a/src/membrain_stats/utils/ripley_utils.py
+++ b/src/membrain_stats/utils/ripley_utils.py
@@ -32,7 +32,9 @@ def get_ripleys_inputs(ripley_stats: List[dict]):
     return distance_matrices, mesh_distances, barycentric_areas
 
 
-def get_xaxis_distances(distance_matrices: List[np.array], num_bins: int):
+def get_xaxis_distances(
+    distance_matrices: List[np.array], num_bins: int, bin_size: float = None
+):
     # flatten protein-protein distances
     all_distances = np.concatenate(
         [np.ravel(distance_matrix) for distance_matrix in distance_matrices]
@@ -44,8 +46,14 @@ def get_xaxis_distances(distance_matrices: List[np.array], num_bins: int):
     all_distances = all_distances[sort_indices]
 
     # split distances into bins
+    if bin_size is not None:
+        max_val = np.max(all_distances[all_distances < np.inf])
+        bins = np.arange(0, max_val, bin_size)
+    else:
+        bins = num_bins
+
     distance_histogram, bin_edges = np.histogram(
-        all_distances[all_distances < np.inf], bins=num_bins
+        all_distances[all_distances < np.inf], bins=bins
     )
     all_distances = bin_edges[:-1]
 
@@ -147,7 +155,10 @@ def define_xy_values(
 
 
 def aggregate_ripleys_stats(
-    ripley_stats: List[dict], ripley_type: str = "L", num_bins: int = 50
+    ripley_stats: List[dict],
+    ripley_type: str = "L",
+    num_bins: int = 50,
+    bin_size: float = None,
 ):
     assert ripley_type in ["K", "L", "O"]
     # extract relevant arrays
@@ -188,7 +199,7 @@ def aggregate_ripleys_stats(
 
     # split protein-protein distances into bins
     all_distances, distance_histogram = get_xaxis_distances(
-        distance_matrices=distance_matrices, num_bins=num_bins
+        distance_matrices=distance_matrices, num_bins=num_bins, bin_size=bin_size
     )
     protein_per_distance = distance_histogram / avg_starting_points
 


### PR DESCRIPTION
This PR adds functionality to set the bin size in angstroms for plotting the geodesic ripley's stats.
Also fixed the issue mentioned in https://github.com/CellArchLab/membrain-stats/issues/16 where the rescaling argument for particle positions was not defined yet.